### PR TITLE
feat: GitHubユーザー名入力時に他プラットフォームへの自動デフォルト値設定機能を実装

### DIFF
--- a/app/status/hooks/useMultiPlatformUserStats.ts
+++ b/app/status/hooks/useMultiPlatformUserStats.ts
@@ -25,7 +25,7 @@ export function useMultiPlatformUserStats() {
       query.github = github;
       primaryUser = github;
     } else if (legacyUser) {
-      // 古い形式の場合はGitHubユーザーとして扱う
+      // 古い形式の場合はGitHubユーザーとして扱い、プライマリユーザーとして設定
       query.github = legacyUser;
       primaryUser = legacyUser;
     }
@@ -33,16 +33,25 @@ export function useMultiPlatformUserStats() {
     if (zenn) {
       query.zenn = zenn;
       if (!primaryUser) primaryUser = zenn;
+    } else if (legacyUser && !zenn) {
+      // 古い形式でZennが指定されていない場合はデフォルト値として設定
+      query.zenn = legacyUser;
     }
 
     if (qiita) {
       query.qiita = qiita;
       if (!primaryUser) primaryUser = qiita;
+    } else if (legacyUser && !qiita) {
+      // 古い形式でQiitaが指定されていない場合はデフォルト値として設定
+      query.qiita = legacyUser;
     }
 
     if (atcoder) {
       query.atcoder = atcoder;
       if (!primaryUser) primaryUser = atcoder;
+    } else if (legacyUser && !atcoder) {
+      // 古い形式でAtCoderが指定されていない場合はデフォルト値として設定
+      query.atcoder = legacyUser;
     }
 
     setCurrentQuery(query);

--- a/components/features/search/MultiPlatformSearchForm.tsx
+++ b/components/features/search/MultiPlatformSearchForm.tsx
@@ -17,10 +17,28 @@ export function MultiPlatformSearchForm({ onSearch, className = '' }: MultiPlatf
   const { addToHistory } = useSearchHistory();
 
   const handleInputChange = (platform: PlatformType, value: string) => {
-    setQuery(prev => ({
-      ...prev,
-      [platform]: value.trim() || undefined,
-    }));
+    const trimmedValue = value.trim() || undefined;
+    
+    setQuery(prev => {
+      const newQuery = {
+        ...prev,
+        [platform]: trimmedValue,
+      };
+
+      // GitHubユーザー名が入力され、他のプラットフォームが空の場合はデフォルト値として設定
+      if (platform === 'github' && trimmedValue) {
+        const otherPlatforms: (keyof SearchQuery)[] = ['zenn', 'qiita', 'atcoder'];
+        
+        otherPlatforms.forEach(otherPlatform => {
+          // 他のプラットフォームが空の場合のみデフォルト値を設定
+          if (!prev[otherPlatform]) {
+            newQuery[otherPlatform] = trimmedValue;
+          }
+        });
+      }
+
+      return newQuery;
+    });
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -132,9 +150,9 @@ export function MultiPlatformSearchForm({ onSearch, className = '' }: MultiPlatf
       <div className="text-xs text-gray-400 dark:text-gray-500 space-y-1">
         <p>💡 ヒント:</p>
         <ul className="list-disc list-inside space-y-1 ml-4">
+          <li>GitHubユーザー名を入力すると、他のプラットフォームにも自動的に同じ値が設定されます</li>
+          <li>各プラットフォームで異なるユーザー名を使用する場合は個別に編集できます</li>
           <li>複数のプラットフォームを同時に検索できます</li>
-          <li>GitHubユーザー名のみでも全プラットフォームの統計を表示します</li>
-          <li>プラットフォーム別に異なるユーザー名を指定できます</li>
         </ul>
       </div>
     </form>


### PR DESCRIPTION
- MultiPlatformSearchFormでGitHubユーザー名入力時に他の空欄にデフォルト値を自動設定
- useMultiPlatformUserStatsで古いuserパラメータ使用時も全プラットフォームにデフォルト値設定
- useEffectを使わずに状態更新時のコールバック内で処理
- 型安全性を保持し、個別編集も可能

Closes #14